### PR TITLE
Frontend-11 - Make the "Add teacher" page for the admin users Frontend-10 - Make the "Add student" page for the admin users

### DIFF
--- a/frontend/frontend_app/src/components/AdminPanel.vue
+++ b/frontend/frontend_app/src/components/AdminPanel.vue
@@ -19,7 +19,7 @@
       <router-link to="/admin/assignment-types" class="admin-panel-item">
         <h2>All Assignment Types</h2>
       </router-link>
-      <router-link to="/groups" class="admin-panel-item">
+      <router-link to="/admin/student_groups" class="admin-panel-item">
         <h2>All Groups</h2>
       </router-link>
       <router-link to="/admin/negotiations" class="admin-panel-item">

--- a/frontend/frontend_app/src/components/FloatingMenuButton.vue
+++ b/frontend/frontend_app/src/components/FloatingMenuButton.vue
@@ -85,12 +85,12 @@ export default {
   position: absolute;
   bottom: 17vh;
   right: 8%;
-  background-color: rgba(255, 255, 255, 0.75);
+  background-color: rgba(255, 255, 255, 0.80);
   padding: 1.5%;
   border-radius: 10px;
   display: none;
   filter: drop-shadow(-5px 8px 5px rgba(0, 0, 0, 0.25));
-  z-index: 1;
+  z-index: 2;
 
 }
 

--- a/frontend/frontend_app/src/routes.ts
+++ b/frontend/frontend_app/src/routes.ts
@@ -63,6 +63,11 @@ const routes: RouteRecordRaw[] =  [
         meta: { requiresAdmin: true } // add meta field to mark the route as requiring admin privileges
     },
     {
+        path: '/teacher/student_groups',
+        component: () => import('./components/StudentsGroup.vue'),
+        meta: { requiresAdmin: true } // add meta field to mark the route as requiring admin privileges
+    },
+    {
         path: '/admin/add_skill_types',
         component: () => import('./components/MainPage.vue')
     },


### PR DESCRIPTION
Frontend-10 - Make the "Add student" page for the admin users
- The functionality was added with the overviews
- Fix floating button's menu transparency
- Update route to student groups in admin panel and add route for teachers for the same page in routes.ts